### PR TITLE
Update database name in connection for MySQL

### DIFF
--- a/server/datasources.json
+++ b/server/datasources.json
@@ -8,7 +8,7 @@
     "connector": "mysql",
     "host": "demo.strongloop.com",
     "port": 3306,
-    "database": "getting_started",
+    "database": "getting_started_intermediate",
     "username": "demo",
     "password": "L00pBack"
   }


### PR DESCRIPTION
**Issue:**

When using remote connection for MySQL it was not working with database name `getting_started`
Thanks to @b-admike we figured out the working database name for remote connection is `getting_started_intermediate`. With that being said it still may make more sense if we have a database named `getting_started ` for remote connection as well for this specific repo; @superkhau shouldn't we create `getting_started` database name for this remote database or we should keep using `getting_started_intermediate`?

/to: @b-admike @superkhau @strongloop/squad-epitome 