### PR TITLE
Set forceId to false for coffeeShop

### DIFF
--- a/common/models/coffee-shop.json
+++ b/common/models/coffee-shop.json
@@ -2,6 +2,7 @@
   "name": "CoffeeShop",
   "base": "PersistedModel",
   "idInjection": true,
+  "forceId": false,
   "options": {
     "validateUpsert": true
   },


### PR DESCRIPTION
Fix of https://github.com/strongloop/loopback-connector-mongodb/issues/331

In loopback 3.x, `forceId` is set to true by default, which disables creating `coffeeshop` instance with `id`, so we need to manually change it by `forceId: false` in model `coffeeshop`'s json file.