### PR TITLE
chore: update loopback-component-explorer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "helmet": "^3.8.2",
     "loopback": "^3.0.0",
     "loopback-boot": "^2.6.5",
-    "loopback-component-explorer": "^4.0.0",
+    "loopback-component-explorer": "^5.0.0",
     "loopback-connector-mysql": "^2.4.0",
     "serve-favicon": "^2.0.1",
     "strong-error-handler": "^1.0.1"


### PR DESCRIPTION
Update `loopback-component-explorer` version from 4.x to 5.x. 