### PR TITLE
fix: security headers handling order

### DIFF
--- a/server/middleware.json
+++ b/server/middleware.json
@@ -4,13 +4,6 @@
   },
   "initial": {
     "compression": {},
-    "cors": {
-      "params": {
-        "origin": true,
-        "credentials": true,
-        "maxAge": 86400
-      }
-    },
     "helmet#xssFilter": {},
     "helmet#frameguard": {
       "params": [
@@ -28,6 +21,13 @@
     "helmet#noSniff": {},
     "helmet#noCache": {
       "enabled": false
+    },
+    "cors": {
+      "params": {
+        "origin": true,
+        "credentials": true,
+        "maxAge": 86400
+      }
     }
   },
   "session": {},


### PR DESCRIPTION




### Description
Hello!
I've had some issue with security headers (`X-Powered-By` exactly) when I tried to use this config "as is". "Helmet" package works well, it erased all `X-Powered-By` in all request, except "OPTIONS" requests. And that's the point.

#### Related issues
Inspired by [this solution](https://github.com/helmetjs/helmet/issues/157#issuecomment-320632798) I decided to place "cors" middleware after "helmet". It works well now.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
